### PR TITLE
sanitize name for freshdesk compatibility

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -111,7 +111,7 @@ app.post('/nominations', async (req, res) => {
       'Nominator Name': stripBadPunc(body.nominatorName),
       'Nominator Email': body.nominatorEmail,
       'Nominator Phone': body.nominatorPhone,
-      Name: body.nomineeName,
+      Name: stripBadPunc(body.nomineeName),
       Email: body.nomineeEmail,
       Phone: body.nomineePhone,
       City: body.nomineeCity,

--- a/src/app.js
+++ b/src/app.js
@@ -108,7 +108,7 @@ app.post('/nominations', async (req, res) => {
     await saveKueJob(createJob.attempts(3))
 
     const nominationJob = queue.create('createNomination', {
-      'Nominator Name': body.nominatorName,
+      'Nominator Name': stripBadPunc(body.nominatorName),
       'Nominator Email': body.nominatorEmail,
       'Nominator Phone': body.nominatorPhone,
       Name: body.nomineeName,

--- a/src/app.js
+++ b/src/app.js
@@ -40,6 +40,9 @@ async function saveKueJob(job) {
     })
   })
 }
+
+const stripBadPunc = str => str ? str.replace(/[",]/g, '') : str
+
 app.enable('trust proxy')
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))
@@ -95,7 +98,7 @@ app.post('/nominations', async (req, res) => {
     }
 
     const createJob = queue.create('createPerson', {
-      name: body.nominatorName,
+      name: stripBadPunc(body.nominatorName),
       email: body.nominatorEmail,
       phone: body.nominatorPhone,
       utmSource: body.utmSource,
@@ -159,7 +162,7 @@ app.post('/people', async (req, res) => {
   try {
     const body = req.body
     const createJob = queue.createJob('createPerson', {
-      name: body.fullName,
+      name: stripBadPunc(body.fullName),
       email: body.email,
       phone: body.phone,
       address: {
@@ -213,7 +216,7 @@ app.post('/volunteers', async (req, res) => {
       tags.push(body.volunteerAvailability)
     }
     const volunteerJob = queue.createJob('createPerson', {
-      name: body.volunteerName,
+      name: stripBadPunc(body.volunteerName),
       email: body.volunteerEmail,
       phone: body.volunteerPhone,
       address: {


### PR DESCRIPTION
This is a minor change to nomination code, based on a problem Sam reported about `"`'s and `,`'s causing odd behaviors in FreshDesk.

It's a really minor change and unlikely to break anything, but how do I test this @saikat?
