### PR TITLE
Add/events endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "moment-timezone": "^0.5.11",
     "monk": "^4.0.0",
     "mustache": "^2.3.0",
+    "nation-pool": "github:brandnewcongress/nation-pool",
     "nodemon": "^1.9.2",
     "normalize-url": "^1.8.0",
     "request-promise": "^4.1.1",

--- a/src/apps/events.js
+++ b/src/apps/events.js
@@ -1,0 +1,42 @@
+const express = require('express')
+const cors = require('cors')
+const client = require('nation-pool/client')
+client.forceStandalone()
+
+const idMap = {
+  'votecoribush.com': 6,
+  coribush: 6
+}
+
+const events = express()
+events.use(cors())
+
+events.get('/events', async (req, res) => {
+  const candidate = req.query.candidate || req.headers.origin
+  const calendarId = idMap[candidate]
+
+  if (!calendarId) {
+    return res.status(400).json({ error: 'Unknown candidate' })
+  }
+
+  const date = new Date()
+  const today = `${date.getFullYear()}-${('0' + (date.getMonth() + 1)).slice(-2)}-${('0' + date.getDate()).slice(-2)}`
+
+  const results = await client.get('sites/brandnewcongress/pages/events', {
+    query: {
+      calendar_id: calendarId,
+      starting: today
+    }
+  })
+
+  return res.json(results.results.map(e => ({
+    url: `http://go.brandnewcongress.org${e.path}`,
+    title: e.headline,
+    startTime: e.start_time,
+    endTime: e.end_time,
+    timeZone: e.time_zone,
+    venue: e.venue
+  })).sort((a, b) => new Date(a.startTime) - new Date(b.startTime)))
+})
+
+module.exports = events

--- a/src/apps/index.js
+++ b/src/apps/index.js
@@ -1,4 +1,5 @@
 const evaluator = require('./evaluator')
 const metrics = require('./metrics')
+const events = require('./events')
 
-module.exports = [evaluator, metrics]
+module.exports = [ evaluator, metrics, events ]

--- a/src/scripts/repost-nominations.js
+++ b/src/scripts/repost-nominations.js
@@ -8,9 +8,9 @@ const query = {
 
 db.get('API Logs').find(query).then(posts => {
   console.log(`Got ${posts.length} posts`)
-  // console.log(posts.slice(posts.length - 5))
+  console.log(posts.slice(posts.length - 1))
 
-  posts.slice(posts.length - 5).forEach(p => {
+  posts.slice(posts.length - 1).forEach(p => {
     request
     .post('https://api.brandnewcongress.org/nominations')
     .send(Object.assign(p.data, {forceSource: 'brandnewcongress.org'}))


### PR DESCRIPTION
Exposes simple GET /events?candidate=<candidate>

Relationship between candidate and calendar id is hardcoded because that seems like the best approach to me – the alternative is fetching all calendars and filtering for the candidate's name.

Starting the migration from `src/nationbuilder` to https://github.com/BrandNewCongress/nation-pool as a nation builder layer, since it can cycle API keys and makes it easier to assign query parameters alongside the token.